### PR TITLE
Fix events fetching when navigating calendar

### DIFF
--- a/CODE/CLIENT/src/hooks/useEventCalendar.ts
+++ b/CODE/CLIENT/src/hooks/useEventCalendar.ts
@@ -126,18 +126,22 @@ export const useEventCalendar = () => {
 
     // ~~
 
-    // Usar uma data fixa baseada no mês atual para evitar conflitos
+    // Usar uma data fixa baseada no mês atual para o carregamento inicial
     const currentMonth = new Date();
     const monthStart = new Date(currentMonth.getFullYear(), currentMonth.getMonth(), 1);
     const monthEnd = new Date(currentMonth.getFullYear(), currentMonth.getMonth() + 1, 0);
 
+    // Range considerado para busca na API: usa o intervalo do calendário, se definido
+    const rangeStart = fullCalendarDateRange?.from ?? monthStart;
+    const rangeEnd = fullCalendarDateRange?.to ?? monthEnd;
+
     const { data: rawEvents = [], isLoading, error, refetch } = useQuery({
-        queryKey: [EVENTS_QUERY_KEY, monthStart, monthEnd],
+        queryKey: [EVENTS_QUERY_KEY, rangeStart.toISOString(), rangeEnd.toISOString()],
         queryFn: async () => {
             const response = await EventService.getEvents(
                 'is-coming',
-                format(monthStart, 'yyyy-MM-dd'),
-                format(monthEnd, 'yyyy-MM-dd')
+                format(rangeStart, 'yyyy-MM-dd'),
+                format(rangeEnd, 'yyyy-MM-dd')
             );
 
             return response || [];


### PR DESCRIPTION
## Summary
- update calendar hook to request events for the visible date range

## Testing
- `npm --prefix CODE/CLIENT run lint` *(fails: Cannot find package '@eslint/js')*
- `npm --prefix CODE/CLIENT run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68755311001c8322b7421eefb0a5ae6a